### PR TITLE
Make splitting of segments use better floating point comparison

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,16 @@ const arcToBezier = ({
     pyp
   )
 
-  const segments = Math.max(Math.ceil(Math.abs(ang2) / (TAU / 4)), 1)
+  // If 'ang2' == 90.0000000001, then `ratio` will evaluate to
+  // 1.0000000001. This causes `segments` to be greater than one, which is an
+  // unecessary split, and adds extra points to the bezier curve. To alleviate
+  // this issue, we round to 1.0 when the ratio is close to 1.0.
+  let ratio = Math.abs(ang2) / (TAU / 4)
+  if (Math.abs(1.0 - ratio) < 0.0000001) {
+    ratio = 1.0
+  }
+
+  const segments = Math.max(Math.ceil(ratio), 1)
 
   ang2 /= segments
 


### PR DESCRIPTION
We were seeing issues where the splitting of the path into cubic bezier segments resulted in too many segments due to the fact that floating point comparison wasn't being handled quite right.